### PR TITLE
fix: remove claimable contract logic; rename wasm_name contract_name

### DIFF
--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -3,7 +3,7 @@ use loam_sdk::soroban_sdk;
 use loam_subcontract_core::{admin::Admin, Core};
 
 use registry::{
-    contract::Contract as Contract_, wasm::Wasm, Claimable, Deployable, DevDeployable, Publishable,
+    contract::Contract as Contract_, wasm::Wasm, Deployable, DevDeployable, Publishable,
 };
 
 pub mod error;
@@ -19,7 +19,6 @@ use version::Version;
     Core(Admin),
     Publishable(Wasm),
     Deployable(Contract_),
-    Claimable(Contract_),
     DevDeployable(Contract_)
 )]
 pub struct Contract;

--- a/contracts/registry/src/registry.rs
+++ b/contracts/registry/src/registry.rs
@@ -13,22 +13,22 @@ pub use wasm::Wasm;
 
 #[loam_sdk::subcontract]
 pub trait IsPublishable {
-    /// Fetch the hash from the registry
+    /// Fetch the hash of a Wasm binary from the registry
     fn fetch_hash(
         &self,
-        contract_name: soroban_sdk::String,
+        wasm_name: soroban_sdk::String,
         version: Option<Version>,
     ) -> Result<soroban_sdk::BytesN<32>, Error> {
-        Ok(self.fetch(contract_name, version)?.hash)
+        Ok(self.fetch(wasm_name, version)?.hash)
     }
 
-    /// Most recent version of the published contract
-    fn current_version(&self, contract_name: soroban_sdk::String) -> Result<Version, Error>;
+    /// Most recent version of the published Wasm binary
+    fn current_version(&self, wasm_name: soroban_sdk::String) -> Result<Version, Error>;
 
     /// Fetch details of the published binary
     fn fetch(
         &self,
-        contract_name: soroban_sdk::String,
+        wasm_name: soroban_sdk::String,
         version: Option<Version>,
     ) -> Result<crate::metadata::PublishedWasm, Error>;
 
@@ -59,10 +59,10 @@ pub trait IsDeployable {
     /// If no salt provided it will use the current sequence number.
     fn deploy(
         &mut self,
-        contract_name: soroban_sdk::String,
+        wasm_name: soroban_sdk::String,
         version: Option<Version>,
-        deployed_name: soroban_sdk::String,
-        owner: soroban_sdk::Address,
+        contract_name: soroban_sdk::String,
+        admin: soroban_sdk::Address,
         salt: Option<soroban_sdk::BytesN<32>>,
         init: Option<(soroban_sdk::Symbol, soroban_sdk::Vec<soroban_sdk::Val>)>,
     ) -> Result<soroban_sdk::Address, Error>;
@@ -70,34 +70,8 @@ pub trait IsDeployable {
     /// Fetch contract id
     fn fetch_contract_id(
         &self,
-        deployed_name: soroban_sdk::String,
+        contract_name: soroban_sdk::String,
     ) -> Result<soroban_sdk::Address, Error>;
-}
-
-#[loam_sdk::subcontract]
-pub trait IsClaimable {
-    /// Claim a contract id of an already deployed contract
-    fn claim_already_deployed_contract(
-        &mut self,
-        deployed_name: soroban_sdk::String,
-        id: soroban_sdk::Address,
-        owner: soroban_sdk::Address,
-    ) -> Result<(), Error>;
-
-    /// Get the owner of a claimed deployed contract
-    fn get_claimed_owner(
-        &self,
-        deployed_name: soroban_sdk::String,
-    ) -> Result<Option<soroban_sdk::Address>, Error>;
-
-    /// Redeploy a claimed deployed contract to a new wasm. Defaults: use redeploy from coreriff
-    fn redeploy_claimed_contract(
-        &self,
-        binary_name: Option<soroban_sdk::String>,
-        version: Option<Version>,
-        deployed_name: soroban_sdk::String,
-        redeploy_fn: Option<(soroban_sdk::Symbol, soroban_sdk::Vec<soroban_sdk::Val>)>,
-    ) -> Result<(), Error>;
 }
 
 #[loam_sdk::subcontract]

--- a/contracts/registry/src/registry/contract.rs
+++ b/contracts/registry/src/registry/contract.rs
@@ -11,7 +11,7 @@ use crate::{
     error::Error, registry::Publishable, util::hash_string, version::Version, Contract as Contract_,
 };
 
-use super::{wasm::Wasm, IsClaimable, IsDeployable, IsDevDeployable};
+use super::{wasm::Wasm, IsDeployable, IsDevDeployable};
 
 loam_sdk::import_contract!(example_core);
 
@@ -24,8 +24,8 @@ loam_sdk::import_contract!(example_core);
 
 #[contracttype]
 pub struct DeployEventData {
-    published_name: String,
-    deployed_name: String,
+    wasm_name: String,
+    contract_name: String,
     version: Version,
     deployer: Address,
     contract_id: Address,
@@ -33,62 +33,39 @@ pub struct DeployEventData {
 
 #[loamstorage]
 pub struct Contract {
-    pub registry: PersistentMap<String, ContractType>,
-}
-
-#[allow(clippy::module_name_repetitions)]
-#[contracttype(export = false)]
-#[derive(Clone)]
-pub enum ContractType {
-    Id(Address),
-    IdAndOwner(Address, Address),
-}
-
-impl ContractType {
-    pub fn contract_id(&self) -> &Address {
-        match self {
-            Self::Id(id) | Self::IdAndOwner(id, _) => id,
-        }
-    }
-    pub fn owner(&self) -> Option<&Address> {
-        match self {
-            Self::IdAndOwner(_, owner) => Some(owner),
-            Self::Id(_) => None,
-        }
-    }
+    pub registry: PersistentMap<String, Address>,
 }
 
 impl IsDeployable for Contract {
     fn deploy(
         &mut self,
-        contract_name: String,
+        wasm_name: String,
         version: Option<Version>,
-        deployed_name: String,
+        contract_name: String,
         owner: Address,
         salt: Option<BytesN<32>>,
         init: Option<(Symbol, soroban_sdk::Vec<soroban_sdk::Val>)>,
     ) -> Result<Address, Error> {
         let env = env();
-        if self.registry.has(deployed_name.clone()) {
+        if self.registry.has(contract_name.clone()) {
             return Err(Error::NoSuchContractDeployed);
         }
         // signed by owner
         owner.require_auth();
-        let hash = Contract_::fetch_hash(contract_name.clone(), version.clone())?;
-        let salt: BytesN<32> = salt.unwrap_or_else(|| hash_string(&deployed_name).into_val(env));
+        let hash = Contract_::fetch_hash(wasm_name.clone(), version.clone())?;
+        let salt: BytesN<32> = salt.unwrap_or_else(|| hash_string(&contract_name).into_val(env));
         let address = deploy_and_init(&owner, salt, hash)?;
         if let Some((init_fn, args)) = init {
             let _ = env.invoke_contract::<Val>(&address, &init_fn, args);
         }
-        self.registry
-            .set(deployed_name.clone(), &ContractType::Id(address.clone()));
+        self.registry.set(contract_name.clone(), &address);
 
         // Publish a deploy event
         let version =
-            version.map_or_else(|| Wasm::default().most_recent_version(&contract_name), Ok)?;
+            version.map_or_else(|| Wasm::default().most_recent_version(&wasm_name), Ok)?;
         let deploy_datas = DeployEventData {
-            published_name: contract_name,
-            deployed_name,
+            wasm_name,
+            contract_name,
             version,
             deployer: owner,
             contract_id: address.clone(),
@@ -99,60 +76,10 @@ impl IsDeployable for Contract {
         Ok(address)
     }
 
-    fn fetch_contract_id(&self, deployed_name: String) -> Result<Address, Error> {
+    fn fetch_contract_id(&self, contract_name: String) -> Result<Address, Error> {
         self.registry
-            .get(deployed_name)
+            .get(contract_name)
             .ok_or(Error::NoSuchContractDeployed)
-            .map(|contract| contract.contract_id().clone())
-    }
-}
-
-impl IsClaimable for Contract {
-    fn claim_already_deployed_contract(
-        &mut self,
-        deployed_name: soroban_sdk::String,
-        id: soroban_sdk::Address,
-        owner: soroban_sdk::Address,
-    ) -> Result<(), Error> {
-        owner.require_auth();
-        if self.registry.has(deployed_name.clone()) {
-            return Err(Error::AlreadyClaimed);
-        }
-        self.registry
-            .set(deployed_name, &ContractType::IdAndOwner(id, owner));
-        Ok(())
-    }
-
-    fn get_claimed_owner(
-        &self,
-        deployed_name: soroban_sdk::String,
-    ) -> Result<Option<Address>, Error> {
-        self.registry
-            .get(deployed_name)
-            .ok_or(Error::NoSuchContractDeployed)
-            .map(|contract| contract.owner().cloned())
-    }
-
-    fn redeploy_claimed_contract(
-        &self,
-        binary_name: Option<soroban_sdk::String>,
-        version: Option<Version>,
-        deployed_name: soroban_sdk::String,
-        redeploy_fn: Option<(soroban_sdk::Symbol, soroban_sdk::Vec<soroban_sdk::Val>)>,
-    ) -> Result<(), Error> {
-        self.get_claimed_owner(deployed_name.clone())?
-            .ok_or(Error::NoOwnerSet)?
-            .require_auth();
-        let contract_id = self.fetch_contract_id(deployed_name)?;
-        if let Some(binary_name) = binary_name {
-            let hash = Contract_::fetch_hash(binary_name, version)?;
-            env().deployer().update_current_contract_wasm(hash);
-        } else if let Some((fn_name, args)) = redeploy_fn {
-            let _ = env().invoke_contract::<Val>(&contract_id, &fn_name, args);
-        } else {
-            return Err(Error::RedeployDeployedFailed);
-        }
-        Ok(())
     }
 }
 
@@ -181,15 +108,14 @@ impl IsDevDeployable for Contract {
         wasm: soroban_sdk::Bytes,
     ) -> Result<soroban_sdk::Address, Error> {
         let wasm_hash = env().deployer().upload_contract_wasm(wasm);
-        if let Some(contract_state) = self.registry.get(name.clone()) {
-            let address = contract_state.contract_id();
-            let contract = example_core::Client::new(env(), address);
+        if let Some(address) = self.registry.get(name.clone()) {
+            let contract = example_core::Client::new(env(), &address);
             contract.redeploy(&wasm_hash);
             return Ok(address.clone());
         }
         let salt = hash_string(&name);
         let id = deploy_and_init(&owner, salt, wasm_hash)?;
-        self.registry.set(name, &ContractType::Id(id.clone()));
+        self.registry.set(name, &id);
         Ok(id)
     }
 }


### PR DESCRIPTION
For simplicity we will assume that all contracts will be published and deployed through the registry.
