### PR TITLE
Fix: missing libs error in workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: rustup update
       - run: rustup target add wasm32-unknown-unknown
+      - run: sudo apt-get update && sudo apt-get install -y libudev-dev libdbus-1-dev pkg-config # required for the machine to build properly
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@just
       

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
         STELLAR_NETWORK_PASSPHRASE: "Standalone Network ; February 2017"
         STELLAR_ACCOUNT: default
         STELLAR_CONTRACT_ID: core
+        PKG_CONFIG_PATH: /usr/lib/pkgconfig
     services:
       rpc:
         image: stellar/quickstart:testing


### PR DESCRIPTION
Fixes the missing library error on the Check workflow, you can use this on other workflows. The workflow still fails, but that's because it's not passing Clippy.

Check out the Github Action output on this PR vs that of the main branch to see the difference.