### PR TITLE
feat(registry): validate names used in registry; to prevent potential issues when used with rust imports

### DIFF
--- a/contracts/registry/src/error.rs
+++ b/contracts/registry/src/error.rs
@@ -27,6 +27,6 @@ pub enum Error {
     /// New version must be greater than the most recent version
     VersionMustBeGreaterThanCurrent = 11,
     /// Invalid name.
-    /// Must be 64 characters or less; ascii alphanumeric or '_';  start with a letter; and not be a Rust keyword
+    /// Must be 64 characters or less; ascii alphanumeric or '_'; start with a letter; and not be a Rust keyword
     InvalidName = 12,
 }

--- a/contracts/registry/src/error.rs
+++ b/contracts/registry/src/error.rs
@@ -27,6 +27,6 @@ pub enum Error {
     /// New version must be greater than the most recent version
     VersionMustBeGreaterThanCurrent = 11,
     /// Invalid name.
-    /// Must be 64 characters or less and be alphanumeric or '_'
+    /// Must be 64 characters or less; ascii alphanumeric or '_';  start with a letter; and not be a Rust keyword
     InvalidName = 12,
 }

--- a/contracts/registry/src/error.rs
+++ b/contracts/registry/src/error.rs
@@ -26,4 +26,7 @@ pub enum Error {
     AdminOnly = 10,
     /// New version must be greater than the most recent version
     VersionMustBeGreaterThanCurrent = 11,
+    /// Invalid name.
+    /// Must be 64 characters or less and be alphanumeric or '_'
+    InvalidName = 12,
 }

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -1,16 +1,15 @@
 #![no_std]
-use loam_sdk::soroban_sdk;
 use loam_subcontract_core::{admin::Admin, Core};
 
 use registry::{contract::C as Contract_, wasm::W as Wasm, Deployable, Publishable, Redeployable};
 
 pub mod error;
+pub mod name;
 pub mod registry;
 pub mod util;
 pub mod version;
 
-use error::Error;
-use version::Version;
+pub use error::Error;
 
 #[loam_sdk::derive_contract(
     Core(Admin),

--- a/contracts/registry/src/name.rs
+++ b/contracts/registry/src/name.rs
@@ -23,7 +23,7 @@ pub(crate) fn validate(s: &String) -> Result<(), Error> {
 }
 
 /// from crate `check_keyword`
-/// https://github.com/JoelCourtney/check_keyword/blob/68486cbfa368070fdbfd383fc5840aa380bb1e6f/src/lib.rs#L120
+/// <https://github.com/JoelCourtney/check_keyword/blob/68486cbfa368070fdbfd383fc5840aa380bb1e6f/src/lib.rs#L120>
 fn is_keyword(s: &str) -> bool {
     match s {
     "as" |

--- a/contracts/registry/src/name.rs
+++ b/contracts/registry/src/name.rs
@@ -1,0 +1,106 @@
+use loam_sdk::soroban_sdk::String;
+
+use crate::error::Error;
+
+pub(crate) fn is_valid(s: &String) -> bool {
+    if s.len() > 64 || s.is_empty() {
+        return false;
+    }
+    let mut out = [0u8; 64];
+    let (first, _) = out.split_at_mut(s.len() as usize);
+    s.copy_into_slice(first);
+    let Ok(s) = core::str::from_utf8(first) else {
+        return false;
+    };
+    if is_keyword(s) || s.starts_with(|c: char| c == '_' || c.is_numeric()) {
+        return false;
+    }
+    s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+pub(crate) fn validate(s: &String) -> Result<(), Error> {
+    is_valid(s).then_some(()).ok_or(Error::InvalidName)
+}
+
+/// from crate `check_keyword`
+/// https://github.com/JoelCourtney/check_keyword/blob/68486cbfa368070fdbfd383fc5840aa380bb1e6f/src/lib.rs#L120
+fn is_keyword(s: &str) -> bool {
+    match s {
+    "as" |
+    "break" |
+    "const" |
+    "continue" |
+    "crate" |
+    "else" |
+    "enum" |
+    "extern" |
+    "false" |
+    "fn" |
+    "for" |
+    "if" |
+    "impl" |
+    "in" |
+    "let" |
+    "loop" |
+    "match" |
+    "mod" |
+    "move" |
+    "mut" |
+    "pub" |
+    "ref" |
+    "return" |
+    "self" |
+    "Self" |
+    "static" |
+    "struct" |
+    "super" |
+    "trait" |
+    "true" |
+    "type" |
+    "unsafe" |
+    "use" |
+    "where" |
+    "while" |
+
+    // STRICT, 2018
+
+    "async"|
+    "await"|
+
+    // DYN
+
+    "dyn" |
+
+    // RESERVED, 2015
+
+    "abstract" |
+    "become" |
+    "box" |
+    "do" |
+    "final" |
+    "macro" |
+    "override" |
+    "priv" |
+    "typeof" |
+    "unsized" |
+    "virtual" |
+    "yield" |
+
+    // RESERVED, 2018
+
+    "try" |
+
+    // RESERVED, 2024
+    "gen" |
+
+    // WEAK
+
+    "macro_rules" |
+    "union" |
+    "'static" |
+
+    // Windows keywords
+    "nul" => true,
+    _ => false
+    }
+}

--- a/contracts/registry/src/registry.rs
+++ b/contracts/registry/src/registry.rs
@@ -1,9 +1,6 @@
-use loam_sdk::soroban_sdk::{self, Lazy};
+use loam_sdk::soroban_sdk::Lazy;
 
-use crate::{
-    error::Error,
-    version::{self, Version},
-};
+use crate::{error::Error, version};
 
 pub mod contract;
 pub mod wasm;
@@ -16,28 +13,31 @@ pub trait IsPublishable {
     /// Fetch the hash of a Wasm binary from the registry
     fn fetch_hash(
         &self,
-        wasm_name: soroban_sdk::String,
+        wasm_name: loam_sdk::soroban_sdk::String,
         version: Option<version::Version>,
-    ) -> Result<soroban_sdk::BytesN<32>, Error>;
+    ) -> Result<loam_sdk::soroban_sdk::BytesN<32>, Error>;
 
     /// Most recent version of the published Wasm binary
-    fn current_version(&self, wasm_name: soroban_sdk::String) -> Result<Version, Error>;
+    fn current_version(
+        &self,
+        wasm_name: loam_sdk::soroban_sdk::String,
+    ) -> Result<version::Version, Error>;
 
     /// Publish a binary. If contract had been previously published only previous author can publish again
     fn publish(
         &mut self,
-        wasm_name: soroban_sdk::String,
-        author: soroban_sdk::Address,
-        wasm: soroban_sdk::Bytes,
+        wasm_name: loam_sdk::soroban_sdk::String,
+        author: loam_sdk::soroban_sdk::Address,
+        wasm: loam_sdk::soroban_sdk::Bytes,
         version: version::Version,
     ) -> Result<(), Error>;
 
     /// Publish a binary. If contract had been previously published only previous author can publish again
     fn publish_hash(
         &mut self,
-        wasm_name: soroban_sdk::String,
-        author: soroban_sdk::Address,
-        wasm_hash: soroban_sdk::BytesN<32>,
+        wasm_name: loam_sdk::soroban_sdk::String,
+        author: loam_sdk::soroban_sdk::Address,
+        wasm_hash: loam_sdk::soroban_sdk::BytesN<32>,
         version: version::Version,
     ) -> Result<(), Error>;
 }
@@ -48,18 +48,18 @@ pub trait IsDeployable {
     /// If no salt provided it will use the current sequence number.
     fn deploy(
         &mut self,
-        wasm_name: soroban_sdk::String,
-        version: Option<Version>,
-        contract_name: soroban_sdk::String,
-        admin: soroban_sdk::Address,
-        init: Option<soroban_sdk::Vec<soroban_sdk::Val>>,
-    ) -> Result<soroban_sdk::Address, Error>;
+        wasm_name: loam_sdk::soroban_sdk::String,
+        version: Option<version::Version>,
+        contract_name: loam_sdk::soroban_sdk::String,
+        admin: loam_sdk::soroban_sdk::Address,
+        init: Option<loam_sdk::soroban_sdk::Vec<loam_sdk::soroban_sdk::Val>>,
+    ) -> Result<loam_sdk::soroban_sdk::Address, Error>;
 
     /// Look up the contract id of a deployed contract
     fn fetch_contract_id(
         &self,
-        contract_name: soroban_sdk::String,
-    ) -> Result<soroban_sdk::Address, Error>;
+        contract_name: loam_sdk::soroban_sdk::String,
+    ) -> Result<loam_sdk::soroban_sdk::Address, Error>;
 }
 
 #[loam_sdk::subcontract]
@@ -67,18 +67,18 @@ pub trait IsRedeployable {
     /// Skips the publish step to deploy a contract directly, keeping the name
     fn dev_deploy(
         &mut self,
-        name: soroban_sdk::String,
-        wasm: soroban_sdk::Bytes,
-        upgrade_fn: Option<soroban_sdk::Symbol>,
-    ) -> Result<soroban_sdk::Address, Error>;
+        name: loam_sdk::soroban_sdk::String,
+        wasm: loam_sdk::soroban_sdk::Bytes,
+        upgrade_fn: Option<loam_sdk::soroban_sdk::Symbol>,
+    ) -> Result<loam_sdk::soroban_sdk::Address, Error>;
 
     /// Upgrades a contract by calling the upgrade function.
     /// Default is 'redeploy' and expects that first arg is the corresponding wasm hash
     fn upgrade_contract(
         &mut self,
-        name: soroban_sdk::String,
-        wasm_name: soroban_sdk::String,
+        name: loam_sdk::soroban_sdk::String,
+        wasm_name: loam_sdk::soroban_sdk::String,
         version: Option<version::Version>,
-        upgrade_fn: Option<soroban_sdk::Symbol>,
-    ) -> Result<soroban_sdk::Address, Error>;
+        upgrade_fn: Option<loam_sdk::soroban_sdk::Symbol>,
+    ) -> Result<loam_sdk::soroban_sdk::Address, Error>;
 }

--- a/contracts/registry/src/registry/contract.rs
+++ b/contracts/registry/src/registry/contract.rs
@@ -11,6 +11,7 @@ use loam_subcontract_core::Core;
 
 use crate::{
     error::Error,
+    name::validate,
     registry::Publishable,
     util::{hash_string, REGISTRY},
     version::Version,
@@ -56,6 +57,7 @@ impl IsDeployable for C {
         admin: Address,
         init: Option<soroban_sdk::Vec<soroban_sdk::Val>>,
     ) -> Result<Address, Error> {
+        validate(&contract_name)?;
         let env = env();
         if self.r.has(contract_name.clone()) {
             return Err(Error::AlreadyDeployed);

--- a/contracts/registry/src/registry/wasm.rs
+++ b/contracts/registry/src/registry/wasm.rs
@@ -6,7 +6,7 @@ use loam_sdk::{
 };
 use loam_subcontract_core::Core as _;
 
-use crate::{error::Error, util::REGISTRY, version::Version};
+use crate::{error::Error, name::validate, util::REGISTRY, version::Version};
 
 use super::IsPublishable;
 
@@ -88,6 +88,7 @@ impl IsPublishable for W {
         wasm_hash: soroban_sdk::BytesN<32>,
         version: Version,
     ) -> Result<(), Error> {
+        validate(&wasm_name)?;
         if let Some(current) = self.author(&wasm_name) {
             if author != current {
                 return Err(Error::AlreadyPublished);

--- a/contracts/registry/src/test.rs
+++ b/contracts/registry/src/test.rs
@@ -115,7 +115,7 @@ fn test_string(s: &str, result: bool) {
     assert!(
         is_valid(&to_string(s)) == result,
         "{s} should be {}valid",
-        if !result { "in" } else { "" }
+        if result { "" } else { "in" }
     );
 }
 

--- a/contracts/registry/src/test.rs
+++ b/contracts/registry/src/test.rs
@@ -1,4 +1,7 @@
-use crate::{error::Error, version::Version, SorobanContract__Client as SorobanContractClient};
+use crate::{
+    error::Error, name::is_valid, version::Version,
+    SorobanContract__Client as SorobanContractClient,
+};
 use assert_matches::assert_matches;
 use loam_sdk::soroban_sdk::{
     self, env, set_env,
@@ -106,4 +109,32 @@ fn returns_most_recent_version() {
     // client.publish(name, &third_hash, &None, &None);
     // let res = client.fetch(name, &None);
     // assert_eq!(res, third_hash);
+}
+
+fn test_string(s: &str, result: bool) {
+    assert!(
+        is_valid(&to_string(s)) == result,
+        "{s} should be {}valid",
+        if !result { "in" } else { "" }
+    );
+}
+
+#[test]
+fn validate_names() {
+    set_env(Env::default());
+    test_string("publish", true);
+    test_string("a_a_b", true);
+    test_string("abcdefghabcdefgh", true);
+    test_string("abcdefghabcdefghabcdefghabcdefgh", true);
+    test_string(
+        "abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh",
+        true,
+    );
+    test_string(
+        "abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgha",
+        false,
+    );
+    test_string("a-a_b", false);
+    test_string("_ab", false);
+    test_string("1ab", false);
 }


### PR DESCRIPTION
Currently requires:
- 0 < len < 65
- ascii alphanumeric with `_`
- cannot start with number or `_`
- cannot be a rust keyword