### PR TITLE
feat!: Use semver::Version instead of custom type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4788,6 +4788,7 @@ dependencies = [
  "assert_matches",
  "loam-sdk",
  "loam-subcontract-core",
+ "semver 1.0.26",
  "stellar-registry",
 ]
 

--- a/contracts/registry/Cargo.toml
+++ b/contracts/registry/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 loam-sdk = { workspace = true }
 loam-subcontract-core = { workspace = true }
+semver = { version = "1.0.26", default-features = false }
 
 
 [dev-dependencies]

--- a/contracts/registry/src/alloc.rs
+++ b/contracts/registry/src/alloc.rs
@@ -1,0 +1,91 @@
+#![allow(static_mut_refs)]
+// This code is adapted from https://github.com/wenyuzhao/bump-allocator-rs
+
+use core::alloc::{GlobalAlloc, Layout};
+
+pub static mut LOCAL_ALLOCATOR: BumpPointerLocal = BumpPointerLocal::new();
+
+pub struct BumpPointerLocal {
+    cursor: *mut u8,
+    limit: *mut u8,
+}
+
+impl BumpPointerLocal {
+    const LOG_PAGE_SIZE: usize = 16;
+    const PAGE_SIZE: usize = 1 << Self::LOG_PAGE_SIZE; // 64KB
+    const MEM: u32 = 0; // Memory 0 is the only legal one currently
+
+    pub const fn new() -> Self {
+        Self {
+            cursor: 0 as _,
+            limit: 0 as _,
+        }
+    }
+
+    #[inline(always)]
+    fn align_allocation(cursor: *mut u8, align: usize) -> *mut u8 {
+        let mask = align - 1;
+        (((cursor as usize) + mask) & !mask) as _
+    }
+
+    #[inline(always)]
+    fn maybe_init_inline(&mut self) {
+        if self.limit as usize == 0 {
+            // This is a slight over-estimate and ideally we would use __heap_base
+            // but that seems not to be easy to access and in any case it is just a
+            // convention whereas this is more guaranteed by the wasm spec to work.
+            self.cursor = (core::arch::wasm32::memory_size(Self::MEM) * Self::PAGE_SIZE) as _;
+            self.limit = self.cursor;
+        }
+    }
+
+    #[inline(never)]
+    fn maybe_init(&mut self) {
+        self.maybe_init_inline()
+    }
+
+    #[inline(always)]
+    pub fn alloc(&mut self, bytes: usize, align: usize) -> *mut u8 {
+        self.maybe_init();
+        let start = Self::align_allocation(self.cursor, align);
+        let new_cursor = unsafe { start.add(bytes) };
+        if new_cursor <= self.limit {
+            self.cursor = new_cursor;
+            start
+        } else {
+            self.alloc_slow(bytes, align)
+        }
+    }
+
+    #[inline(always)]
+    fn alloc_slow_inline(&mut self, bytes: usize, align: usize) -> *mut u8 {
+        let pages = (bytes + Self::PAGE_SIZE - 1) / Self::PAGE_SIZE;
+        if core::arch::wasm32::memory_grow(Self::MEM, pages) == usize::MAX {
+            panic!()
+        }
+        self.limit = unsafe { self.limit.add(pages * Self::PAGE_SIZE) };
+        self.alloc(bytes, align)
+    }
+
+    #[inline(never)]
+    fn alloc_slow(&mut self, bytes: usize, align: usize) -> *mut u8 {
+        self.alloc_slow_inline(bytes, align)
+    }
+}
+
+pub struct BumpPointer;
+
+unsafe impl GlobalAlloc for BumpPointer {
+    #[inline(always)]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let (bytes, align) = (layout.size(), layout.align());
+        let ptr = LOCAL_ALLOCATOR.alloc(bytes, align);
+        ptr
+    }
+
+    #[inline(always)]
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}
+
+#[global_allocator]
+static GLOBAL: BumpPointer = BumpPointer;

--- a/contracts/registry/src/error.rs
+++ b/contracts/registry/src/error.rs
@@ -29,4 +29,6 @@ pub enum Error {
     /// Invalid name.
     /// Must be 64 characters or less; ascii alphanumeric or '_'; start with a letter; and not be a Rust keyword
     InvalidName = 12,
+    /// Invalid Version. Must be valid cargo version
+    InvalidVersion = 13,
 }

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -9,6 +9,9 @@ pub mod registry;
 pub mod util;
 pub mod version;
 
+#[cfg(target_family = "wasm")]
+mod alloc;
+
 pub use error::Error;
 
 #[loam_sdk::derive_contract(

--- a/contracts/registry/src/registry.rs
+++ b/contracts/registry/src/registry.rs
@@ -1,6 +1,6 @@
 use loam_sdk::soroban_sdk::Lazy;
 
-use crate::{error::Error, version};
+use crate::error::Error;
 
 pub mod contract;
 pub mod wasm;
@@ -14,14 +14,14 @@ pub trait IsPublishable {
     fn fetch_hash(
         &self,
         wasm_name: loam_sdk::soroban_sdk::String,
-        version: Option<version::Version>,
+        version: Option<loam_sdk::soroban_sdk::String>,
     ) -> Result<loam_sdk::soroban_sdk::BytesN<32>, Error>;
 
     /// Most recent version of the published Wasm binary
     fn current_version(
         &self,
         wasm_name: loam_sdk::soroban_sdk::String,
-    ) -> Result<version::Version, Error>;
+    ) -> Result<loam_sdk::soroban_sdk::String, Error>;
 
     /// Publish a binary. If contract had been previously published only previous author can publish again
     fn publish(
@@ -29,7 +29,7 @@ pub trait IsPublishable {
         wasm_name: loam_sdk::soroban_sdk::String,
         author: loam_sdk::soroban_sdk::Address,
         wasm: loam_sdk::soroban_sdk::Bytes,
-        version: version::Version,
+        version: loam_sdk::soroban_sdk::String,
     ) -> Result<(), Error>;
 
     /// Publish a binary. If contract had been previously published only previous author can publish again
@@ -38,7 +38,7 @@ pub trait IsPublishable {
         wasm_name: loam_sdk::soroban_sdk::String,
         author: loam_sdk::soroban_sdk::Address,
         wasm_hash: loam_sdk::soroban_sdk::BytesN<32>,
-        version: version::Version,
+        version: loam_sdk::soroban_sdk::String,
     ) -> Result<(), Error>;
 }
 
@@ -49,7 +49,7 @@ pub trait IsDeployable {
     fn deploy(
         &mut self,
         wasm_name: loam_sdk::soroban_sdk::String,
-        version: Option<version::Version>,
+        version: Option<loam_sdk::soroban_sdk::String>,
         contract_name: loam_sdk::soroban_sdk::String,
         admin: loam_sdk::soroban_sdk::Address,
         init: Option<loam_sdk::soroban_sdk::Vec<loam_sdk::soroban_sdk::Val>>,
@@ -78,7 +78,7 @@ pub trait IsRedeployable {
         &mut self,
         name: loam_sdk::soroban_sdk::String,
         wasm_name: loam_sdk::soroban_sdk::String,
-        version: Option<version::Version>,
+        version: Option<loam_sdk::soroban_sdk::String>,
         upgrade_fn: Option<loam_sdk::soroban_sdk::Symbol>,
     ) -> Result<loam_sdk::soroban_sdk::Address, Error>;
 }

--- a/contracts/registry/src/registry/contract.rs
+++ b/contracts/registry/src/registry/contract.rs
@@ -14,7 +14,6 @@ use crate::{
     name::validate,
     registry::Publishable,
     util::{hash_string, REGISTRY},
-    version::Version,
     Contract as Contract_,
 };
 
@@ -24,7 +23,7 @@ use super::{wasm::W, IsDeployable, IsRedeployable};
 pub struct DeployEventData {
     wasm_name: String,
     contract_name: String,
-    version: Version,
+    version: String,
     deployer: Address,
     contract_id: Address,
 }
@@ -52,7 +51,7 @@ impl IsDeployable for C {
     fn deploy(
         &mut self,
         wasm_name: String,
-        version: Option<Version>,
+        version: Option<String>,
         contract_name: String,
         admin: Address,
         init: Option<soroban_sdk::Vec<soroban_sdk::Val>>,
@@ -125,7 +124,7 @@ impl IsRedeployable for C {
         &mut self,
         name: String,
         wasm_name: String,
-        version: Option<Version>,
+        version: Option<String>,
         upgrade_fn: Option<Symbol>,
     ) -> Result<Address, Error> {
         let wasm_hash = Contract_::fetch_hash(wasm_name.clone(), version.clone())?;

--- a/contracts/registry/src/registry/wasm.rs
+++ b/contracts/registry/src/registry/wasm.rs
@@ -4,7 +4,7 @@ use loam_sdk::{
 };
 use loam_subcontract_core::Core as _;
 
-use crate::{error::Error, name::validate, util::REGISTRY, version};
+use crate::{error::Error, name::validate, util::REGISTRY};
 
 use super::IsPublishable;
 
@@ -58,10 +58,9 @@ impl W {
     }
 
     fn validate_version(&self, version: &String, wasm_name: &String) -> Result<(), Error> {
-        let parsed_version = version::parse(&version)?;
+        let version = crate::version::parse(version)?;
         if let Ok(current_version) = self.most_recent_version(wasm_name) {
-            let current_version = version::parse(&current_version)?;
-            if parsed_version <= current_version {
+            if version <= crate::version::parse(&current_version)? {
                 return Err(Error::VersionMustBeGreaterThanCurrent);
             }
         }

--- a/contracts/registry/src/registry/wasm.rs
+++ b/contracts/registry/src/registry/wasm.rs
@@ -1,19 +1,17 @@
 use loam_sdk::{
     loamstorage,
-    soroban_sdk::{
-        self, assert_with_error, env, to_string, Address, BytesN, Map, PersistentMap, String,
-    },
+    soroban_sdk::{self, env, to_string, Address, BytesN, Map, PersistentMap, String},
 };
 use loam_subcontract_core::Core as _;
 
-use crate::{error::Error, name::validate, util::REGISTRY, version::Version};
+use crate::{error::Error, name::validate, util::REGISTRY, version};
 
 use super::IsPublishable;
 
 /// Contains
 #[loamstorage]
 pub struct W {
-    pub r: PersistentMap<String, Map<Version, BytesN<32>>>,
+    pub r: PersistentMap<String, Map<String, BytesN<32>>>,
     pub a: PersistentMap<String, Address>,
 }
 
@@ -26,19 +24,19 @@ impl W {
 }
 
 impl W {
-    fn registry(&self, name: &String) -> Result<Map<Version, BytesN<32>>, Error> {
+    fn registry(&self, name: &String) -> Result<Map<String, BytesN<32>>, Error> {
         self.r
             .get(name.clone())
             .ok_or(Error::NoSuchContractPublished)
     }
-    pub fn most_recent_version(&self, name: &String) -> Result<Version, Error> {
+    pub fn most_recent_version(&self, name: &String) -> Result<String, Error> {
         self.registry(name)?
             .keys()
             .first()
             .ok_or(Error::NoSuchVersion)
     }
 
-    pub fn get(&self, name: &String, version: Option<Version>) -> Result<BytesN<32>, Error> {
+    pub fn get(&self, name: &String, version: Option<String>) -> Result<BytesN<32>, Error> {
         let registry = self.registry(name)?;
         if let Some(version) = version {
             registry.get(version)
@@ -48,12 +46,7 @@ impl W {
         .ok_or(Error::NoSuchVersion)
     }
 
-    pub fn set(
-        &mut self,
-        name: &String,
-        version: Version,
-        binary: BytesN<32>,
-    ) -> Result<(), Error> {
+    pub fn set(&mut self, name: &String, version: String, binary: BytesN<32>) -> Result<(), Error> {
         let mut registry = self.r.get(name.clone()).unwrap_or_else(|| Map::new(env()));
         registry.set(version, binary);
         self.r.set(name.clone(), &registry);
@@ -63,10 +56,21 @@ impl W {
     pub fn author(&self, name: &String) -> Option<Address> {
         self.a.get(name.clone())
     }
+
+    fn validate_version(&self, version: &String, wasm_name: &String) -> Result<(), Error> {
+        let parsed_version = version::parse(&version)?;
+        if let Ok(current_version) = self.most_recent_version(wasm_name) {
+            let current_version = version::parse(&current_version)?;
+            if parsed_version <= current_version {
+                return Err(Error::VersionMustBeGreaterThanCurrent);
+            }
+        }
+        Ok(())
+    }
 }
 
 impl IsPublishable for W {
-    fn current_version(&self, contract_name: String) -> Result<Version, Error> {
+    fn current_version(&self, contract_name: String) -> Result<String, Error> {
         self.most_recent_version(&contract_name)
     }
 
@@ -75,7 +79,7 @@ impl IsPublishable for W {
         wasm_name: String,
         author: Address,
         wasm: soroban_sdk::Bytes,
-        version: Version,
+        version: String,
     ) -> Result<(), Error> {
         let wasm_hash = env().deployer().upload_contract_wasm(wasm);
         self.publish_hash(wasm_name, author, wasm_hash, version)
@@ -86,30 +90,19 @@ impl IsPublishable for W {
         wasm_name: soroban_sdk::String,
         author: soroban_sdk::Address,
         wasm_hash: soroban_sdk::BytesN<32>,
-        version: Version,
+        version: String,
     ) -> Result<(), Error> {
+        author.require_auth();
         validate(&wasm_name)?;
         if let Some(current) = self.author(&wasm_name) {
             if author != current {
                 return Err(Error::AlreadyPublished);
             }
         }
-        if wasm_name == to_string(REGISTRY) {
-            assert_with_error!(
-                env(),
-                crate::Contract::admin_get().unwrap() == author,
-                Error::AdminOnly
-            );
+        if wasm_name == to_string(REGISTRY) && crate::Contract::admin_get().unwrap() != author {
+            return Err(Error::AdminOnly);
         }
-        author.require_auth();
-        version.log();
-        if let Ok(current_version) = self.most_recent_version(&wasm_name) {
-            assert_with_error!(
-                env(),
-                version > current_version,
-                Error::VersionMustBeGreaterThanCurrent
-            );
-        }
+        self.validate_version(&version, &wasm_name)?;
         self.a.set(wasm_name.clone(), &author);
         self.set(&wasm_name, version, wasm_hash)
     }
@@ -117,7 +110,7 @@ impl IsPublishable for W {
     fn fetch_hash(
         &self,
         contract_name: String,
-        version: Option<Version>,
+        version: Option<String>,
     ) -> Result<BytesN<32>, Error> {
         self.get(&contract_name, version)
     }

--- a/contracts/registry/src/test.rs
+++ b/contracts/registry/src/test.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::Error, name::is_valid, version::Version,
+    error::Error, name::is_valid,
     SorobanContract__Client as SorobanContractClient,
 };
 use assert_matches::assert_matches;
@@ -9,6 +9,10 @@ use loam_sdk::soroban_sdk::{
     to_string, Address, Bytes, BytesN, Env, IntoVal,
 };
 extern crate std;
+
+fn default_version() -> soroban_sdk::String  {
+    to_string("0.0.0")
+}
 
 stellar_registry::import_contract_client!(stellar_registry_contract);
 // Equivalent to:
@@ -56,13 +60,13 @@ fn handle_error_cases() {
 
     let bytes = Bytes::from_slice(env, stellar_registry_contract::WASM);
     env.mock_all_auths();
-    let version = Version::default();
+    let version = default_version();
     client.publish(name, address, &bytes, &version);
     assert_eq!(client.fetch_hash(name, &None), wasm_hash);
 
     assert_matches!(
         client
-            .try_fetch_hash(name, &Some(version.publish_patch()))
+            .try_fetch_hash(name, &Some(to_string("0.0.1")))
             .unwrap_err(),
         Ok(Error::NoSuchVersion)
     );
@@ -82,7 +86,7 @@ fn returns_most_recent_version() {
     // client.register_name(address, name);
     let bytes = Bytes::from_slice(env, stellar_registry_contract::WASM);
     env.mock_all_auths();
-    let version = Version::default();
+    let version = default_version();
     client.publish(name, address, &bytes, &version);
     let fetched_hash = client.fetch_hash(name, &None);
     let wasm_hash = env
@@ -95,20 +99,10 @@ fn returns_most_recent_version() {
         name,
         address,
         &second_hash.into_val(env),
-        &version.publish_patch(),
+        &to_string("0.0.1"),
     );
     let res = client.fetch_hash(name, &None);
     assert_eq!(res, second_hash);
-
-    // let third_hash: BytesN<32> = BytesN::random(env);
-    // client.publish(name, &third_hash, &None, &None);
-    // let res = client.fetch(name, &None);
-    // assert_eq!(res, third_hash);
-
-    // let third_hash: BytesN<32> = BytesN::random(env);
-    // client.publish(name, &third_hash, &None, &None);
-    // let res = client.fetch(name, &None);
-    // assert_eq!(res, third_hash);
 }
 
 fn test_string(s: &str, result: bool) {

--- a/contracts/registry/src/version.rs
+++ b/contracts/registry/src/version.rs
@@ -1,71 +1,18 @@
-use core::fmt::Display;
+use loam_sdk::soroban_sdk::String;
 
-use loam_sdk::soroban_sdk::{self, contracttype, env, log, Env};
+use crate::Error;
 
-/// Represents the version of the contract
-#[contracttype]
-#[derive(Default, Eq, PartialEq, PartialOrd, Clone, Debug)]
-pub struct Version(u32, u32, u32);
+const MAX_VERSION_LENGTH: usize = 200;
 
-pub const INITAL_VERSION: Version = Version(0, 0, 1);
-
-impl Display for Version {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "v{}.{}.{}", self.major(), self.minor(), self.patch())
+pub fn parse(s: &String) -> Result<semver::Version, Error> {
+    if s.len() as usize > MAX_VERSION_LENGTH || s.is_empty() {
+        return Err(Error::InvalidVersion);
     }
-}
-
-impl Version {
-    pub(crate) fn log(&self) {
-        log!(env(), "v{}.{}.{}", self.major(), self.minor(), self.patch());
-    }
-
-    #[must_use]
-    pub fn publish_patch(mut self) -> Self {
-        self.2 += 1;
-        self
-    }
-
-    #[must_use]
-    pub fn publish_minor(mut self) -> Self {
-        self.1 += 1;
-        self.2 = 0;
-        self
-    }
-    #[must_use]
-    pub fn publish_major(mut self) -> Self {
-        self.0 += 1;
-        self.1 = 0;
-        self.2 = 0;
-        self
-    }
-
-    #[must_use]
-    pub fn update(self, kind: &Update) -> Self {
-        match kind {
-            Update::Patch => self.publish_patch(),
-            Update::Minor => self.publish_minor(),
-            Update::Major => self.publish_major(),
-        }
-    }
-    pub fn patch(&self) -> u32 {
-        self.2
-    }
-
-    pub fn minor(&self) -> u32 {
-        self.1
-    }
-
-    pub fn major(&self) -> u32 {
-        self.0
-    }
-}
-
-#[contracttype]
-#[derive(Default)]
-pub enum Update {
-    #[default]
-    Patch,
-    Minor,
-    Major,
+    let mut out = [0u8; MAX_VERSION_LENGTH];
+    let (first, _) = out.split_at_mut(s.len() as usize);
+    s.copy_into_slice(first);
+    let Ok(s) = core::str::from_utf8(first) else {
+        return Err(Error::InvalidVersion);
+    };
+    Ok(s.parse().map_err(|_| Error::InvalidVersion)?)
 }

--- a/contracts/registry/src/version.rs
+++ b/contracts/registry/src/version.rs
@@ -14,5 +14,5 @@ pub fn parse(s: &String) -> Result<semver::Version, Error> {
     let Ok(s) = core::str::from_utf8(first) else {
         return Err(Error::InvalidVersion);
     };
-    Ok(s.parse().map_err(|_| Error::InvalidVersion)?)
+    s.parse().map_err(|_| Error::InvalidVersion)
 }


### PR DESCRIPTION
Since Cargo.toml stores versions as strings and users will expect to be able to use them directly when passing a version, this PR uses strings as inputs and stores the versions as strings. It also uses the `semver` crate to validate that the input version strings and to ensure that a publish can only publish a version that is greater than the most recent one!

This also has the added benefit of handling any version type cargo supports such as prereleases!

