### PR TITLE
upgrade a project to a scaffold project

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,10 @@ jobs:
       - run: rustup update
       - run: rustup target add wasm32v1-none
       - run: rustup component add rustfmt clippy
-      - run: sudo apt-get update # required for the machine to build properly
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@just
       - uses: cargo-bins/cargo-binstall@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,3 @@
-
 name: RPC Tests
 on:
   push:
@@ -34,6 +33,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
+        sudo apt-get install -y libdbus-1-dev pkg-config
     - uses: actions/cache@v3
       with:
         path: |
@@ -52,4 +52,3 @@ jobs:
     - run: just setup
     - run: just create
     - run: just test-integration
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1251,6 +1251,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -4760,6 +4773,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5346,6 +5365,7 @@ dependencies = [
  "cargo_toml",
  "clap 4.5.35",
  "degit",
+ "dialoguer",
  "dirs",
  "flate2",
  "fs_extra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +624,8 @@ version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -686,6 +694,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-markdown"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a2617956a06d4885b490697b5307ebb09fec10b088afc18c81762d848c2339"
+dependencies = [
+ "clap 4.5.35",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +748,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1045,6 +1073,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71ea7f29c73f7ffa64c50b83c9fe4d3a6d4be89a86b009eb80d5a6d3429d741"
+dependencies = [
+ "cc",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36a8232661d66dcf713394726157d3cfe0a89bfc85f52d6e9f9bbc2306797fe7"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f44296c8693e9ea226a48f6a122727f77aa9e9e338380cb021accaeeb7ee279"
+dependencies = [
+ "clap 4.5.35",
+ "codespan-reporting",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f69c181c176981ae44ba9876e2ea41ce8e574c296b38d06925ce9214fb8e4"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8faff5d4467e0709448187df29ccbf3b0982cc426ee444a193f87b11afb565a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1171,30 @@ name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+
+[[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
+dependencies = [
+ "dbus",
+ "futures-util",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "degit"
@@ -1446,6 +1557,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1837,6 +1954,18 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hidapi"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798154e4b6570af74899d71155fb0072d5b17e6aa12f39c8ef22c60fb8ec99e7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "hmac"
@@ -2565,6 +2694,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2798,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1961983669d57bdfe6c0f3ef8e4c229b5ef751afcc7d87e4271d2f71f6ccfa8b"
+dependencies = [
+ "byteorder 1.5.0",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.2.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,10 +2844,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "ledger-apdu"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe435806c197dfeaa5efcded5e623c4b8230fd28fdf1e91e7a86e40ef2acbf90"
+dependencies = [
+ "arrayref",
+ "no-std-compat",
+ "snafu",
+]
+
+[[package]]
+name = "ledger-transport"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1117f2143d92c157197785bf57711d7b02f2cfa101e162f8ca7900fb7f976321"
+dependencies = [
+ "async-trait",
+ "ledger-apdu",
+]
+
+[[package]]
+name = "ledger-transport-hid"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ba81a1f5f24396b37211478aff7fbcd605dd4544df8dbed07b9da3c2057aee"
+dependencies = [
+ "byteorder 1.5.0",
+ "cfg-if 1.0.0",
+ "hex",
+ "hidapi",
+ "ledger-transport",
+ "libc",
+ "log",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -2711,6 +2910,15 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
  "redox_syscall 0.5.11",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2959,7 +3167,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2980,6 +3188,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "normalize-line-endings"
@@ -3017,12 +3231,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3049,6 +3286,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg 1.4.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4100,7 +4359,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -4212,6 +4471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scratch"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52"
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,6 +4507,19 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.0",
  "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4564,6 +4842,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "snafu"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4588,8 +4888,7 @@ dependencies = [
 [[package]]
 name = "soroban-cli"
 version = "22.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e049e0014fbf660be8cef1973ba5e937d54e0534ac20a6f4f37daf1500c87d97"
+source = "git+https://github.com/AhaLabs/stellar-cli?branch=feat/expose-build-custom-cmd#dbcc34df1ae6b5b0dfd23908ab5cfe0a7a4c99bb"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -4599,6 +4898,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap 4.5.35",
+ "clap-markdown",
  "clap_complete",
  "crate-git-revision",
  "csv",
@@ -4618,6 +4918,7 @@ dependencies = [
  "itertools 0.10.5",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
+ "keyring",
  "num-bigint",
  "open",
  "pathdiff",
@@ -4642,14 +4943,15 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-json",
  "soroban-spec-rust",
- "soroban-spec-tools",
+ "soroban-spec-tools 22.8.1 (git+https://github.com/AhaLabs/stellar-cli?branch=feat/expose-build-custom-cmd)",
  "soroban-spec-typescript",
+ "stellar-ledger",
  "stellar-rpc-client",
  "stellar-strkey 0.0.11",
  "stellar-xdr",
  "strsim 0.11.1",
- "strum",
- "strum_macros",
+ "strum 0.17.1",
+ "strum_macros 0.17.1",
  "tempfile",
  "termcolor",
  "termcolor_output",
@@ -4664,6 +4966,7 @@ dependencies = [
  "ulid",
  "url 2.5.4",
  "wasm-gen",
+ "wasm-opt",
  "wasmparser",
  "which",
  "whoami",
@@ -4821,8 +5124,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec-json"
 version = "22.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a0ae994cf244b4b8192d71577b39e3d656710d7affd52e2d42adf7eb48be02"
+source = "git+https://github.com/AhaLabs/stellar-cli?branch=feat/expose-build-custom-cmd#dbcc34df1ae6b5b0dfd23908ab5cfe0a7a4c99bb"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4868,10 +5170,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-spec-tools"
+version = "22.8.1"
+source = "git+https://github.com/AhaLabs/stellar-cli?branch=feat/expose-build-custom-cmd#dbcc34df1ae6b5b0dfd23908ab5cfe0a7a4c99bb"
+dependencies = [
+ "base64 0.21.7",
+ "ethnum",
+ "hex",
+ "itertools 0.10.5",
+ "serde_json",
+ "soroban-spec",
+ "stellar-strkey 0.0.11",
+ "stellar-xdr",
+ "thiserror 1.0.69",
+ "wasmparser",
+]
+
+[[package]]
 name = "soroban-spec-typescript"
 version = "22.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dc43fa28880f1c3d721b64e5d3f41dcc9785cda26590af41e34f8c68bee97c"
+source = "git+https://github.com/AhaLabs/stellar-cli?branch=feat/expose-build-custom-cmd#dbcc34df1ae6b5b0dfd23908ab5cfe0a7a4c99bb"
 dependencies = [
  "base64 0.21.7",
  "heck 0.4.1",
@@ -4938,6 +5256,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-ledger"
+version = "22.8.1"
+source = "git+https://github.com/AhaLabs/stellar-cli?branch=feat/expose-build-custom-cmd#dbcc34df1ae6b5b0dfd23908ab5cfe0a7a4c99bb"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "byteorder 1.5.0",
+ "ed25519-dalek",
+ "hex",
+ "home",
+ "ledger-transport",
+ "ledger-transport-hid",
+ "reqwest 0.12.15",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.8",
+ "slipped10",
+ "stellar-strkey 0.0.11",
+ "stellar-xdr",
+ "thiserror 1.0.69",
+ "tokio 1.44.2",
+ "tracing",
+]
+
+[[package]]
 name = "stellar-registry"
 version = "0.0.2"
 dependencies = [
@@ -4959,7 +5303,7 @@ dependencies = [
  "sha2 0.10.8",
  "shlex",
  "soroban-cli",
- "soroban-spec-tools",
+ "soroban-spec-tools 22.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stellar-rpc-client",
  "stellar-scaffold-test",
  "stellar-strkey 0.0.11",
@@ -5025,6 +5369,7 @@ dependencies = [
  "sha2 0.10.8",
  "shlex",
  "soroban-cli",
+ "soroban-spec-tools 22.8.1 (git+https://github.com/AhaLabs/stellar-cli?branch=feat/expose-build-custom-cmd)",
  "stellar-build",
  "stellar-rpc-client",
  "stellar-scaffold-test",
@@ -5151,6 +5496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "530efb820d53b712f4e347916c5e7ed20deb76a4f0457943b3182fb889b06d2c"
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
 name = "strum_macros"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5159,6 +5510,19 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn 1.0.109",
 ]
 
@@ -6153,6 +6517,46 @@ checksum = "b854b1461005a7b3365742310f7faa3cac3add809d66928c64a40c7e9e842ebb"
 dependencies = [
  "byteorder 0.5.3",
  "leb128",
+]
+
+[[package]]
+name = "wasm-opt"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd87a4c135535ffed86123b6fb0f0a5a0bc89e50416c942c5f0662c645f679c"
+dependencies = [
+ "anyhow",
+ "libc",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "tempfile",
+ "thiserror 1.0.69",
+ "wasm-opt-cxx-sys",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-cxx-sys"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
+dependencies = [
+ "anyhow",
+ "cxx",
+ "cxx-build",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-sys"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ stellar-registry = { path = "crates/stellar-registry" }
 
 loam-sdk = { git = "https://github.com/loambuild/loam", rev = "096da30cedd371651906cfbed034b955c7b50ab4" }
 loam-subcontract-core = { git = "https://github.com/loambuild/loam", rev = "096da30cedd371651906cfbed034b955c7b50ab4" }
-stellar-cli = { version = "22.8.1", package = "soroban-cli" }
+stellar-cli = { git = "https://github.com/AhaLabs/stellar-cli", branch = "feat/expose-build-custom-cmd", package = "soroban-cli" }
 soroban-rpc = { package = "stellar-rpc-client", version = "22.0.0" }
 
 soroban-sdk = "22.0.0-rc.3"

--- a/crates/stellar-scaffold-cli/Cargo.toml
+++ b/crates/stellar-scaffold-cli/Cargo.toml
@@ -38,6 +38,7 @@ clap = { version = "4.1.8", features = [
     "string",
 ] }
 degit = "0.1.3"
+dialoguer = "0.11.0"
 dirs = "6.0.0"
 flate2 = "1.0"
 tar = "0.4"

--- a/crates/stellar-scaffold-cli/Cargo.toml
+++ b/crates/stellar-scaffold-cli/Cargo.toml
@@ -30,6 +30,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 stellar-build = { path = "../stellar-build", version = "0.0.2" }
 stellar-cli = { workspace = true}
 soroban-rpc = { workspace = true}
+soroban-spec-tools = { git = "https://github.com/AhaLabs/stellar-cli", branch = "feat/expose-build-custom-cmd", package = "soroban-spec-tools" }
 clap = { version = "4.1.8", features = [
     "derive",
     "env",

--- a/crates/stellar-scaffold-cli/README.md
+++ b/crates/stellar-scaffold-cli/README.md
@@ -2,9 +2,11 @@
 
 CLI toolkit for Stellar smart contract development, providing project scaffolding, build automation, and development workflow tools.
 
-Stellar Scaffold CLI comes with three main commands:
+Stellar Scaffold CLI comes with four main commands:
 
 * `stellar scaffold init` - Creates a new Stellar smart contract project with best practices and configurations in place, including an `environments.toml` file for managing network settings, accounts, and contracts across different environments.
+
+* `stellar scaffold upgrade` - Transforms an existing Soroban workspace into a full scaffold project by adding frontend components, environment configurations, and project structure. Preserves existing contracts while adding the complete development toolkit.
 
 * `stellar scaffold build` - Manages two key build processes:
   * Build smart contracts with metadata and handle dependencies
@@ -15,6 +17,8 @@ Stellar Scaffold CLI comes with three main commands:
 * `stellar scaffold watch` - Development mode that monitors contract source files and `environments.toml` for changes, automatically rebuilding as needed. Defaults to using the `development` environment.
 
 ## Getting Started
+
+### New Project
 
 1. Install the CLI:
 ```bash
@@ -27,7 +31,7 @@ Or [`cargo-binstall`](github.com/cargo-bins/cargo-binstall):
 cargo binstall stellar-scaffold-cli
 ```
 
-1. Create a new project:
+2. Create a new project:
 ```bash
 stellar scaffold init my-project
 cd my-project
@@ -37,6 +41,20 @@ This creates:
 - A smart contract project with recommended configurations
 - A frontend application based on [scaffold-stellar-frontend](https://github.com/AhaLabs/scaffold-stellar-frontend)
 - Environment configurations for both contract and frontend development
+
+### Upgrading Existing Workspace
+
+If you have an existing Soroban workspace, you can upgrade it to a full scaffold project:
+```bash
+cd my-existing-workspace
+stellar scaffold upgrade
+```
+
+This will:
+- Add the frontend application and development tools
+- Generate `environments.toml` with your existing contracts
+- Set up environment files and configurations
+- Preserve all your existing contract code and structure
 
 3. Set up your environment:
 ```bash
@@ -51,7 +69,6 @@ stellar scaffold watch --build-clients
 ## Environment Configuration
 
 Projects use `environments.toml` to define network settings, accounts, and contract configurations for different environments. Example:
-
 ```toml
 [development]
 network = { 

--- a/crates/stellar-scaffold-cli/src/commands/mod.rs
+++ b/crates/stellar-scaffold-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod build;
 pub mod generate;
 pub mod init;
 pub mod update_env;
+pub mod upgrade;
 pub mod watch;
 
 const ABOUT: &str = "Build smart contracts with frontend support";
@@ -41,10 +42,11 @@ impl Root {
     pub async fn run(&mut self) -> Result<(), Error> {
         match &mut self.cmd {
             Cmd::Init(init_info) => init_info.run(&self.global_args).await?,
-            Cmd::Build(build_info) => build_info.run().await?, // todo pass global args to build and watch
+            Cmd::Build(build_info) => build_info.run().await?,
             Cmd::Generate(generate) => match &mut generate.cmd {
                 generate::Command::Contract(contract) => contract.run(&self.global_args).await?,
             },
+            Cmd::Upgrade(upgrade_info) => upgrade_info.run(&self.global_args).await?,
             Cmd::UpdateEnv(e) => e.run()?,
             Cmd::Watch(watch_info) => watch_info.run().await?,
         }
@@ -71,6 +73,9 @@ pub enum Cmd {
     /// generate contracts
     Generate(generate::Cmd),
 
+    /// Upgrade an existing Soroban workspace to a scaffold project
+    Upgrade(upgrade::Cmd),
+
     /// Update an environment variable in a .env file
     UpdateEnv(update_env::Cmd),
 
@@ -87,6 +92,8 @@ pub enum Error {
     BuildContracts(#[from] build::Error),
     #[error(transparent)]
     Contract(#[from] generate::contract::Error),
+    #[error(transparent)]
+    Upgrade(#[from] upgrade::Error),
     #[error(transparent)]
     UpdateEnv(#[from] update_env::Error),
     #[error(transparent)]

--- a/crates/stellar-scaffold-cli/src/commands/upgrade.rs
+++ b/crates/stellar-scaffold-cli/src/commands/upgrade.rs
@@ -405,8 +405,7 @@ impl Cmd {
 
         // Display help text before the prompt
         println!("\n  --{arg_name}");
-        if value_name != "bool" && !help_text.is_empty()
-        {
+        if value_name != "bool" && !help_text.is_empty() {
             println!("   {help_text}");
         }
 

--- a/crates/stellar-scaffold-cli/src/commands/upgrade.rs
+++ b/crates/stellar-scaffold-cli/src/commands/upgrade.rs
@@ -462,12 +462,13 @@ impl Cmd {
         let mut select = Select::new()
             .with_prompt(format!("Select value for --{arg_name}"))
             .default(0); // This will show the cursor on the first option initially
-        
+
         // Add "Skip" option
         select = select.item("(Skip - leave blank)");
 
         // Parse the values from "a | b | c" format and add numeric options
-        for value in value_name.split('|') {
+        let values: Vec<&str> = value_name.split('|').collect();
+        for value in &values {
             select = select.item(format!("Value: {value}"));
         }
 

--- a/crates/stellar-scaffold-cli/src/commands/upgrade.rs
+++ b/crates/stellar-scaffold-cli/src/commands/upgrade.rs
@@ -1,0 +1,439 @@
+use crate::commands::build::env_toml::{Account, Contract, Environment, Network};
+use clap::Parser;
+use degit::degit;
+use indexmap::IndexMap;
+use std::fs;
+use std::fs::{create_dir_all, metadata, read_dir, write};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use toml_edit::{value, DocumentMut, Item, Table};
+
+use crate::commands::build;
+use stellar_cli::print::Print;
+
+const FRONTEND_TEMPLATE: &str = "https://github.com/AhaLabs/scaffold-stellar-frontend";
+
+/// A command to upgrade an existing Soroban workspace to a scaffold project
+#[derive(Parser, Debug, Clone)]
+pub struct Cmd {
+    /// The path to the existing workspace (defaults to current directory)
+    #[arg(default_value = ".")]
+    pub workspace_path: PathBuf,
+}
+
+/// Errors that can occur during upgrade
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Failed to clone template: {0}")]
+    DegitError(String),
+    #[error(
+        "Workspace path contains invalid UTF-8 characters and cannot be converted to a string"
+    )]
+    InvalidWorkspacePathEncoding,
+    #[error("IO error: {0}")]
+    IoError(#[from] io::Error),
+    #[error("No Cargo.toml found in workspace path")]
+    NoCargoToml,
+    #[error("No contracts/ directory found in workspace path")]
+    NoContractsDirectory,
+    #[error("Invalid package name in Cargo.toml")]
+    InvalidPackageName,
+    #[error("Failed to parse TOML: {0}")]
+    TomlParseError(#[from] toml_edit::TomlError),
+    #[error("Failed to serialize TOML: {0}")]
+    TomlSerializeError(#[from] toml::ser::Error),
+    #[error("Failed to deserialize TOML: {0}")]
+    TomlDeserializeError(#[from] toml::de::Error),
+    #[error(transparent)]
+    BuildError(#[from] build::Error),
+    #[error("Failed to get constructor arguments: {0}")]
+    ConstructorArgsError(String),
+    #[error(transparent)]
+    Clap(#[from] clap::Error),
+    #[error(transparent)]
+    SorobanSpecTools(#[from] soroban_spec_tools::contract::Error),
+    #[error(transparent)]
+    CopyError(#[from] fs_extra::error::Error),
+}
+
+impl Cmd {
+    /// Run the upgrade command
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// /// From the command line
+    /// stellar scaffold upgrade /path/to/workspace
+    /// ```
+    pub async fn run(
+        &self,
+        global_args: &stellar_cli::commands::global::Args,
+    ) -> Result<(), Error> {
+        let printer = Print::new(global_args.quiet);
+
+        printer.infoln(format!(
+            "Upgrading Soroban workspace to scaffold project in {:?}",
+            self.workspace_path
+        ));
+
+        // Validate workspace
+        self.validate_workspace()?;
+
+        // Create temporary directory for frontend template
+        let temp_dir = tempfile::tempdir().map_err(Error::IoError)?;
+        let temp_path = temp_dir.path();
+
+        printer.infoln("Downloading frontend template...");
+        Self::clone_frontend_template(temp_path)?;
+
+        printer.infoln("Copying frontend files...");
+        self.copy_frontend_files(temp_path)?;
+
+        printer.infoln("Setting up environment file...");
+        self.setup_env_file()?;
+
+        printer.infoln("Creating environments.toml...");
+        self.create_environments_toml().await?;
+
+        printer.checkln(format!(
+            "Workspace successfully upgraded to scaffold project at {:?}",
+            self.workspace_path
+        ));
+
+        Ok(())
+    }
+
+    fn validate_workspace(&self) -> Result<(), Error> {
+        // Check for Cargo.toml
+        let cargo_toml = self.workspace_path.join("Cargo.toml");
+        if !cargo_toml.exists() {
+            return Err(Error::NoCargoToml);
+        }
+
+        // Check for contracts/ directory
+        let contracts_dir = self.workspace_path.join("contracts");
+        if !contracts_dir.exists() {
+            return Err(Error::NoContractsDirectory);
+        }
+
+        Ok(())
+    }
+
+    fn clone_frontend_template(temp_path: &Path) -> Result<(), Error> {
+        let temp_str = temp_path
+            .to_str()
+            .ok_or(Error::InvalidWorkspacePathEncoding)?;
+
+        degit(FRONTEND_TEMPLATE, temp_str);
+
+        if metadata(temp_path).is_err() || read_dir(temp_path)?.next().is_none() {
+            return Err(Error::DegitError(format!(
+                "Failed to clone template into {temp_str}: directory is empty or missing",
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn copy_frontend_files(&self, temp_path: &Path) -> Result<(), Error> {
+        // Files and directories to skip (don't copy from template)
+        let skip_items = ["contracts", "environments.toml", "Cargo.toml"];
+
+        // Copy all items from template except the ones we want to skip
+        for entry in read_dir(temp_path)? {
+            let entry = entry?;
+            let item_name = entry.file_name();
+
+            // Skip items that shouldn't be copied
+            if let Some(name_str) = item_name.to_str() {
+                if skip_items.contains(&name_str) {
+                    continue;
+                }
+            }
+
+            let src = entry.path();
+            let dest = self.workspace_path.join(&item_name);
+
+            // Don't overwrite existing files/directories
+            if dest.exists() {
+                continue;
+            }
+
+            if src.is_dir() {
+                let copy_options = fs_extra::dir::CopyOptions::new()
+                    .overwrite(false) // Don't overwrite existing files
+                    .skip_exist(true); // Skip files that already exist
+
+                fs_extra::dir::copy(&src, &self.workspace_path, &copy_options)?;
+            } else {
+                let copy_options = fs_extra::file::CopyOptions::new().overwrite(false); // Don't overwrite existing files
+
+                fs_extra::file::copy(&src, &dest, &copy_options)?;
+            }
+        }
+
+        // Create packages directory if it doesn't exist
+        let packages_dir = self.workspace_path.join("packages");
+        if !packages_dir.exists() {
+            create_dir_all(&packages_dir)?;
+        }
+
+        Ok(())
+    }
+
+    async fn create_environments_toml(&self) -> Result<(), Error> {
+        let env_path = self.workspace_path.join("environments.toml");
+
+        // Don't overwrite existing environments.toml
+        if env_path.exists() {
+            return Ok(());
+        }
+
+        // Discover contracts by looking in contracts/ directory
+        let contracts = self.discover_contracts()?;
+
+        // Build contracts to get WASM files for constructor arg analysis
+        self.build_contracts().await?;
+
+        // Get constructor args for each contract
+        let contract_configs = contracts
+            .iter()
+            .map(|contract_name| {
+                let constructor_args = self.get_constructor_args(contract_name)?;
+                Ok((
+                    contract_name.clone().into_boxed_str(),
+                    Contract {
+                        constructor_args,
+                        ..Default::default()
+                    },
+                ))
+            })
+            .collect::<Result<IndexMap<_, _>, Error>>()?;
+
+        let env_config = Environment {
+            accounts: Some(vec![Account {
+                name: "default".to_string(),
+                default: true,
+            }]),
+            network: Network {
+                name: None,
+                rpc_url: Some("http://localhost:8000/rpc".to_string()),
+                network_passphrase: Some("Standalone Network ; February 2017".to_string()),
+                rpc_headers: None,
+                run_locally: true,
+            },
+            contracts: if contract_configs.is_empty() {
+                None
+            } else {
+                Some(contract_configs)
+            },
+        };
+
+        let mut doc = DocumentMut::new();
+
+        // Add development environment
+        let mut dev_table = Table::new();
+
+        // Add accounts
+        let mut accounts_array = toml_edit::Array::new();
+        accounts_array.push("default");
+        dev_table["accounts"] = Item::Value(accounts_array.into());
+
+        // Add network
+        let mut network_table = Table::new();
+        network_table["rpc-url"] = value(env_config.network.rpc_url.as_ref().unwrap());
+        network_table["network-passphrase"] =
+            value(env_config.network.network_passphrase.as_ref().unwrap());
+        network_table["run-locally"] = value(env_config.network.run_locally);
+        dev_table["network"] = Item::Table(network_table);
+
+        // Add contracts
+        let contracts_table = env_config
+            .contracts
+            .as_ref()
+            .map(|contracts| {
+                contracts
+                    .iter()
+                    .map(|(name, config)| {
+                        let mut contract_constructor_args = Table::new();
+                        if let Some(args) = &config.constructor_args {
+                            contract_constructor_args["constructor_args"] = value(args);
+                        }
+                        // Convert hyphens to underscores for contract names in TOML
+                        let contract_key = name.replace('-', "_");
+                        (contract_key, Item::Table(contract_constructor_args))
+                    })
+                    .collect::<Table>()
+            })
+            .unwrap_or_default();
+
+        dev_table["contracts"] = Item::Table(contracts_table);
+
+        doc["development"] = Item::Table(dev_table);
+
+        write(&env_path, doc.to_string())?;
+
+        Ok(())
+    }
+
+    fn discover_contracts(&self) -> Result<Vec<String>, Error> {
+        let contracts_dir = self.workspace_path.join("contracts");
+
+        let contracts = std::fs::read_dir(&contracts_dir)?
+            .map(|entry_res| -> Result<Option<String>, Error> {
+                let entry = entry_res?;
+                let path = entry.path();
+
+                // skip non-directories or dirs without Cargo.toml
+                let cargo_toml = path.join("Cargo.toml");
+                if !path.is_dir() || !cargo_toml.exists() {
+                    return Ok(None);
+                }
+
+                // this read_to_string can now fail and will be propagated
+                let content = std::fs::read_to_string(&cargo_toml)?;
+                if !content.contains("cdylib") {
+                    return Ok(None);
+                }
+
+                // parse and extract package.name, propagating any toml errors
+                let tv = content.parse::<toml::Value>()?;
+                let name = tv
+                    .get("package")
+                    .and_then(|p| p.get("name"))
+                    .and_then(|n| n.as_str())
+                    .ok_or_else(|| Error::InvalidPackageName)?;
+
+                Ok(Some(name.to_string()))
+            })
+            .collect::<Result<Vec<Option<String>>, Error>>()? // bubbles up any Err
+            .into_iter()
+            .flatten()
+            .collect();
+
+        Ok(contracts)
+    }
+
+    async fn build_contracts(&self) -> Result<(), Error> {
+        // Run scaffold build to generate WASM files
+        let build_cmd = build::Command {
+            build_clients_args: build::clients::Args {
+                env: Some(build::clients::ScaffoldEnv::Development),
+                workspace_root: Some(self.workspace_path.clone()),
+                out_dir: None,
+            },
+            build: stellar_cli::commands::contract::build::Cmd {
+                manifest_path: None,
+                package: None,
+                profile: "release".to_string(),
+                features: None,
+                all_features: false,
+                no_default_features: false,
+                out_dir: None,
+                print_commands_only: false,
+                meta: Vec::new(),
+            },
+            list: false,
+            build_clients: false, // Don't build clients, just contracts
+        };
+
+        build_cmd.run().await?;
+        Ok(())
+    }
+
+    fn get_constructor_args(&self, contract_name: &str) -> Result<Option<String>, Error> {
+        // Get the WASM file path
+        let target_dir = self.workspace_path.join("target");
+        let wasm_path = stellar_build::stellar_wasm_out_file(&target_dir, contract_name);
+
+        if !wasm_path.exists() {
+            return Ok(None);
+        }
+
+        // Read the WASM file and get spec entries
+        let raw_wasm = fs::read(&wasm_path)?;
+        let entries = soroban_spec_tools::contract::Spec::new(&raw_wasm)?.spec;
+        let spec = soroban_spec_tools::Spec::new(entries.clone());
+
+        // Check if constructor function exists
+        let constructor_result = spec.find_function("__constructor");
+        match constructor_result {
+            Ok(func) => {
+                if func.inputs.is_empty() {
+                    return Ok(None);
+                }
+
+                // Build the custom command for the constructor
+                let cmd = stellar_cli::commands::contract::arg_parsing::build_custom_cmd(
+                    "__constructor",
+                    &spec,
+                )
+                .map_err(|e| {
+                    Error::ConstructorArgsError(format!("Failed to build constructor command: {e}"))
+                })?;
+
+                println!("\n📋 Contract '{contract_name}' requires constructor arguments:");
+
+                let mut args = Vec::new();
+
+                // Loop through the command arguments, skipping file args
+                for arg in cmd.get_arguments() {
+                    let arg_name = arg.get_id().as_str();
+
+                    // Skip file arguments (they end with -file-path)
+                    if arg_name.ends_with("-file-path") {
+                        continue;
+                    }
+
+                    // Show the argument help
+                    if let Some(help) = arg.get_long_help().or(arg.get_help()) {
+                        println!("  --{arg_name} {help}");
+                    } else if let Some(value_name) =
+                        arg.get_value_names().and_then(|names| names.first())
+                    {
+                        println!("  --{arg_name} <{value_name}>");
+                    } else {
+                        println!("  --{arg_name}");
+                    }
+
+                    print!("Enter value for --{arg_name}: ");
+                    io::stdout().flush()?;
+
+                    let mut value = String::new();
+                    io::stdin().read_line(&mut value)?;
+                    let value = value.trim();
+
+                    if value.is_empty() {
+                        // Create a TODO placeholder for this argument
+                        args.push(format!("--{arg_name} # TODO: Fill in value"));
+                    } else {
+                        args.push(format!("--{arg_name} {value}"));
+                    }
+                }
+
+                if args.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(args.join(" ")))
+                }
+            }
+            Err(_) => {
+                // No constructor function found
+                Ok(None)
+            }
+        }
+    }
+
+    fn setup_env_file(&self) -> Result<(), Error> {
+        let env_example_path = self.workspace_path.join(".env.example");
+        let env_path = self.workspace_path.join(".env");
+
+        // Only copy if .env.example exists and .env doesn't exist
+        if env_example_path.exists() && !env_path.exists() {
+            let copy_options = fs_extra::file::CopyOptions::new();
+            fs_extra::file::copy(&env_example_path, &env_path, &copy_options)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/stellar-scaffold-cli/src/lib.rs
+++ b/crates/stellar-scaffold-cli/src/lib.rs
@@ -3,8 +3,8 @@
     clippy::must_use_candidate,
     clippy::missing_panics_doc
 )]
-pub mod commands;
 mod arg_parsing;
+pub mod commands;
 
 use std::path::Path;
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,10 +18,32 @@ The init command creates:
 - A frontend application using the [scaffold-stellar-frontend](https://github.com/AhaLabs/scaffold-stellar-frontend) template
 - Configuration files for both contract and frontend development
 
+## Upgrade Command
+
+Transform an existing Soroban workspace into a full scaffold project:
+```bash
+stellar scaffold upgrade [workspace-path]
+```
+
+Options:
+- `workspace-path`: Path to existing workspace (defaults to current directory)
+
+The upgrade command:
+- Validates the existing workspace (requires `Cargo.toml` and `contracts/` directory)
+- Downloads and integrates the frontend template
+- Generates `environments.toml` with discovered contracts
+- Analyzes contracts for constructor arguments and prompts for configuration
+- Preserves all existing contract code and project structure
+- Adds development tools and configurations
+
+Requirements for upgrade:
+- Must have a `Cargo.toml` file in the workspace root
+- Must have a `contracts/` directory with Soroban contracts
+- Contracts should be properly configured as `cdylib` crates
+
 ## Build Command
 
 Build contracts and generate frontend client packages:
-
 ```bash
 stellar scaffold build [options]
 ```
@@ -34,7 +56,6 @@ Options:
 ## Dev Command
 
 Start development mode with hot reloading:
-
 ```bash
 stellar scaffold watch [options]
 ```


### PR DESCRIPTION
Upgrades an existing stellar workspace to a scaffold workspace. Run `stellar scaffold upgrade` in the directory of your workspace (requires a Cargo.toml file and a contracts directory). 

Example output:
```
~/projects/scaffold-stellar/target/debug/stellar-scaffold upgrade .
ℹ️  Upgrading Soroban workspace to scaffold project in "."
ℹ️  Downloading frontend template...
Downloading AhaLabs/scaffold-stellar-frontend from GitHub to /tmp/.tmpBCBgyk
  Done...
ℹ️  Copying frontend files...
ℹ️  Setting up environment file...
ℹ️  Creating environments.toml...
ℹ️  CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/home/blaine/.cargo/registry/src= cargo rustc --manifest-path=contracts/non_fungible/Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
    Finished `release` profile [optimized] target(s) in 0.03s
ℹ️  Build Summary:
   Wasm File: target/stellar/non_fungible_contract.wasm
   Wasm Hash: aa0cfd2437cefdd797ee7934b85e207c99d52cdfa04988e302907e534a160189
   Exported Functions: 21 found
     • _
     • __constructor
     • approve
     • approve_for_all
     • balance
     • get_approved
     • get_owner_token_id
     • get_token_id
     • is_approved_for_all
     • name
     • owner_of
     • pause
     • paused
     • sequential_mint
     • symbol
     • token_uri
     • total_supply
     • transfer
     • transfer_from
     • unpause
     • upgrade
✅ Build Complete

📋 Contract 'non-fungible-contract' requires constructor arguments:
  --owner Can be public key (G13..), a contract hash (6c45307) or an identity (alice), 
Example:
  --owner GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
Enter value for --owner: default
✅ Workspace successfully upgraded to scaffold project at "."
```