### PR TITLE
Fix: Build clients race condition

### DIFF
--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -359,6 +359,7 @@ export default new Client.Client({{
             }
             eprintln!("✅ Client {name:?} updated successfully");
         } else {
+            std::fs::create_dir_all(&final_output_dir)?;
             // No existing directory, just move temp to final location
             std::fs::rename(&temp_dir, &final_output_dir)?;
             eprintln!("✅ Client {name:?} created successfully");

--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -6,6 +6,7 @@ use serde_json;
 use shlex::split;
 use std::fmt::Debug;
 use std::hash::Hash;
+use std::path::Path;
 use std::process::Command;
 use stellar_cli::commands::NetworkRunnable;
 use stellar_cli::utils::contract_hash;
@@ -352,10 +353,11 @@ export default new Client.Client({{
 
         // Now atomically replace the old directory with the new one
         if final_output_dir.exists() {
-            if let Err(e) = std::fs::rename(&temp_dir, &final_output_dir) {
-                // Failed to move new directory, clean up temp directory
-                std::fs::remove_dir_all(&temp_dir)?;
-                return Err(Error::Io(e));
+            for p in ["dist/index.d.ts", "dist/index.js", "src/index.ts"]
+                .iter()
+                .map(Path::new)
+            {
+                std::fs::copy(temp_dir.join(p), final_output_dir.join(p))?;
             }
             eprintln!("✅ Client {name:?} updated successfully");
         } else {

--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -379,7 +379,7 @@ export default new Client.Client({{
             std::fs::rename(&final_output_dir, &backup_dir)?;
 
             match std::fs::rename(&temp_dir, &final_output_dir) {
-                Ok(_) => {
+                Ok(()) => {
                     // Success! Clean up backup
                     let _ = std::fs::remove_dir_all(&backup_dir);
                     eprintln!("✅ Client {name:?} updated successfully");

--- a/crates/stellar-scaffold-cli/tests/it/build_clients/contracts.rs
+++ b/crates/stellar-scaffold-cli/tests/it/build_clients/contracts.rs
@@ -41,7 +41,6 @@ soroban_token_contract.client = false
             assert!(stderr.contains(&format!("installing \"{c}\" wasm bytecode on-chain")));
             assert!(stderr.contains(&format!("instantiating \"{c}\" smart contract")));
             assert!(stderr.contains(&format!("binding \"{c}\" contract")));
-            assert!(stderr.contains(&format!("importing \"{c}\" contract")));
 
             // check that contracts are actually deployed, bound, and imported
             assert!(env.cwd.join(format!("packages/{c}")).exists());
@@ -93,7 +92,6 @@ soroban_token_contract.client = false
             assert!(stderr.contains(&format!("installing \"{c}\" wasm bytecode on-chain")));
             assert!(stderr.contains(&format!("instantiating \"{c}\" smart contract")));
             assert!(stderr.contains(&format!("binding \"{c}\" contract")));
-            assert!(stderr.contains(&format!("importing \"{c}\" contract")));
 
             // check that contracts are actually deployed, bound, and imported
             assert!(env.cwd.join(format!("packages/{c}")).exists());
@@ -161,7 +159,7 @@ soroban_token_contract.client = false
         // ensure it imports
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stderr)
-            .contains("🍽️ importing \"soroban_hello_world_contract\" contract"));
+            .contains("binding \"soroban_hello_world_contract\" contract"));
 
         let output2 = env
             .stellar_scaffold_env("development", false)
@@ -362,7 +360,6 @@ soroban_token_contract.client = false
         );
         assert!(stderr.contains("instantiating \"soroban_hello_world_contract\" smart contract"));
         assert!(stderr.contains("binding \"soroban_hello_world_contract\" contract"));
-        assert!(stderr.contains("importing \"soroban_hello_world_contract\" contract"));
 
         // Check that WASM file was copied to custom out_dir
         assert!(out_dir.join("soroban_hello_world_contract.wasm").exists());


### PR DESCRIPTION
Previously, the client build process deleted the old contract code before building and installing the new ones. While running in watch mode concurrently with the frontend dev server, this caused a hot-reload which would throw an error since app code is importing contracts that don't exist until rebuilt.

This change builds and installs the contracts in a temp directory then replaces the contract code at once, ensuring only one hot-reload and no broken imports. This has the added benefit of being able to use the old contract code as a backup if the build/install process fails for any reason.