### PR TITLE
docs: better help docs for root commands

### DIFF
--- a/crates/stellar-registry-cli/src/commands/mod.rs
+++ b/crates/stellar-registry-cli/src/commands/mod.rs
@@ -7,7 +7,7 @@ pub mod install;
 pub mod publish;
 pub mod version;
 
-const ABOUT: &str = "Publish and install Soroban contracts";
+const ABOUT: &str = "Add, manage, and use Wasm packages & named contracts in the Stellar Registry";
 
 #[derive(Parser, Debug)]
 #[command(
@@ -56,14 +56,14 @@ impl FromStr for Root {
 
 #[derive(Parser, Debug)]
 pub enum Cmd {
-    /// publish contract to registry
+    /// Publish Wasm to registry with package name and semantic version
     Publish(Box<publish::Cmd>),
+    /// Deploy a named contract from a published Wasm
+    Deploy(Box<deploy::Cmd>),
+    /// Create a local `stellar contract alias` from a named registry contract
+    Install(Box<install::Cmd>),
     /// Version of the scaffold-registry-cli
     Version(version::Cmd),
-    /// deploy contract from deployed Wasm
-    Deploy(Box<deploy::Cmd>),
-    /// install contracts
-    Install(Box<install::Cmd>),
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
```
$ stellar registry -h
Add, manage, and use Wasm packages & named contracts in the Stellar Registry

Usage: stellar-registry <COMMAND>

Commands:
  publish  Publish Wasm to registry with package name and semantic version
  deploy   Deploy a named contract from a published Wasm
  install  Create a local `stellar contract alias` from a named registry contract
  version  Version of the scaffold-registry-cli
```