### PR TITLE
fix(build-clients): only `allowHttp` in dev & test

### DIFF
--- a/crates/stellar-scaffold-cli/src/commands/build/clients.rs
+++ b/crates/stellar-scaffold-cli/src/commands/build/clients.rs
@@ -262,7 +262,9 @@ impl Args {
     }
 
     fn create_contract_template(&self, name: &str, contract_id: &str) -> Result<(), Error> {
-        let allow_http = if self.stellar_scaffold_env(ScaffoldEnv::Production) == "production" {
+        let allow_http = if ["development", "test"]
+            .contains(&self.stellar_scaffold_env(ScaffoldEnv::Production).as_str())
+        {
             "\n  allowHttp: true,"
         } else {
             ""


### PR DESCRIPTION
This got switched around by mistake in 1bb8c7e35af9b5632f0515aab5c5c929fe58a870

We need tests on this! But for now it's a show-stopping bug (no local environment works correctly without this), and I have verified that it works correctly by using it in a local project.