### PR TITLE
feat: update CD github actions to do a dry run on a release PR

### DIFF
--- a/.github/workflows/cd-registry-cli.yml
+++ b/.github/workflows/cd-registry-cli.yml
@@ -8,6 +8,9 @@ on:
   push:
     tags:
       - "stellar-registry-cli-v[0-9]+.[0-9]+.[0-9]+*"
+  pull_request:
+    paths:
+      - crates/stellar-registry-cli/CHANGELOG.md
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_GIT_FETCH_WITH_CLI: true
@@ -81,5 +84,6 @@ jobs:
           zip: windows
           archive: $tag-$target
           token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: ${{ github.event_name == 'pull_request' }}
         env:
           OPENSSL_STATIC: ${{ env.OPENSSL_STATIC }}

--- a/.github/workflows/cd-scaffold-cli.yml
+++ b/.github/workflows/cd-scaffold-cli.yml
@@ -8,6 +8,9 @@ on:
   push:
     tags:
       - "stellar-scaffold-cli-v[0-9]+.[0-9]+.[0-9]+*"
+  pull_request:
+    paths:
+      - crates/stellar-scaffold-cli/CHANGELOG.md
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_GIT_FETCH_WITH_CLI: true
@@ -81,5 +84,6 @@ jobs:
           zip: windows
           archive: $tag-$target
           token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: ${{ github.event_name == 'pull_request' }}
         env:
           OPENSSL_STATIC: ${{ env.OPENSSL_STATIC }}


### PR DESCRIPTION
When a release PR updates the changelog for either CLI this triggers a dry run. Ensuring that when we do a release we the binaries will build.